### PR TITLE
サイコロクラスの追加とGitHub Actionsのテスト設定

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
-        pip install pytest
-
-    - name: Run tests
+        pip install pytest pytest-cov
+  
+    - name: Run tests with coverage
       env:
         PYTHONPATH: ${{ github.workspace }}
-      run: pytest
+      run: pytest --cov=calculator --cov-report=term-missing

--- a/calculator/dice.py
+++ b/calculator/dice.py
@@ -1,0 +1,16 @@
+import random
+
+class Dice:
+    def __init__(self, sides=6):
+        """
+        sides: サイコロの面の数（デフォルトは6面）
+        """
+        if sides < 1:
+            raise ValueError("サイコロの面の数は1以上でなければなりません")
+        self.sides = sides
+
+    def roll(self):
+        """
+        サイコロを振り、1から面の数までのランダムな値を返す
+        """
+        return random.randint(1, self.sides)

--- a/tests/test_dice.py
+++ b/tests/test_dice.py
@@ -1,0 +1,20 @@
+import unittest
+from calculator.dice import Dice
+
+class TestDice(unittest.TestCase):
+    def test_roll_with_default_sides(self):
+        dice = Dice()
+        result = dice.roll()
+        self.assertTrue(1 <= result <= 6)
+
+    def test_roll_with_custom_sides(self):
+        dice = Dice(sides=12)
+        result = dice.roll()
+        self.assertTrue(1 <= result <= 12)
+
+    def test_invalid_sides(self):
+        with self.assertRaises(ValueError):
+            Dice(sides=0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

- サイコロの目をランダムに生成する`Dice`クラスを追加しました。
- GitHub Actionsのワークフローを設定し、`pytest`を使用した単体テストを自動実行するようにしました。

## 変更内容

1. **`Dice`クラスの追加**
   - `calculator/dice.py`にサイコロの目をランダムに生成するクラスを実装。
   - 面の数を指定可能（デフォルトは6面）。
   - 面の数が1未満の場合に例外をスローするバリデーションを追加。

2. **単体テストの追加**
   - `tests/test_dice.py`に`Dice`クラスの単体テストを実装。
   - `pytest`を使用してテストを実行。

3. **GitHub Actionsの設定**
   - `.github/workflows/test.yml`を追加。
   - プッシュやプルリクエスト時に自動でテストを実行。
   - `PYTHONPATH`を設定し、プロジェクトルートをモジュール検索パスに追加。

## 動作確認

- ローカル環境で`pytest`を実行し、すべてのテストが成功することを確認。
- GitHub ActionsでCIが正常に動作することを確認。

## 確認してほしい点

- `Dice`クラスの設計や実装に問題がないか。
- テストケースが十分かどうか。
- GitHub Actionsの設定が適切か。

---

レビューをよろしくお願いいたします！